### PR TITLE
Fix Neptun link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # neptun629
 
-Aesthetic portfolio theme for developers released under [the MIT License](https://github.com/tomasz-oponowicz/neptun629/blob/master/LICENSE.txt). The _Neptun 629_ is a model name of [the first mass-produced television set](http://stare-telewizory.republika.pl/grafika/katalog/duze/kat79/neptun426.jpg). It suggests an old school style and a focus on basics. The Neptun629 theme is partially based on the amazing [Ghostwriter theme](https://github.com/roryg/ghostwriter). 
+Aesthetic portfolio theme for developers released under [the MIT License](https://github.com/tomasz-oponowicz/neptun629/blob/master/LICENSE.txt). The _Neptun 629_ is a model name of [the first mass-produced television set](http://staretelewizory.cba.pl/katalog/neptun426.html). It suggests an old school style and a focus on basics. The Neptun629 theme is partially based on the amazing [Ghostwriter theme](https://github.com/roryg/ghostwriter).
 
 Key features include:
 


### PR DESCRIPTION
Previous link leads to a 404 site. The corrected one includes a graphic and a short description of Neptun 426.